### PR TITLE
Fix scroll performance for widgets with huge content

### DIFF
--- a/lib/widgets/element.js
+++ b/lib/widgets/element.js
@@ -530,7 +530,8 @@ Element.prototype._parseAttr = function(lines) {
     , j
     , c;
 
-  if (lines[0].attr === attr) {
+  if (Array.isArray(lines.attr) && lines.attr.length > 0
+      && lines.attr[0] === attr) {
     return;
   }
 

--- a/test/widget-huge-content.js
+++ b/test/widget-huge-content.js
@@ -1,0 +1,45 @@
+var blessed = require('../')
+  , screen;
+
+screen = blessed.screen({
+  dump: __dirname + '/logs/huge-content.log',
+  smartCSR: true,
+  warnings: true
+});
+
+var content = '';
+for (var j = 0; j < 2000; j++) {
+  for (var i = 0; i < 100; i++) {
+    content += 'line: ' + i + '\n';
+  }
+  for (var i = 0; i < 10000; i++) {
+    content += 'longline';
+  }
+  content += '\n';
+}
+
+var box = blessed.box({
+  parent: screen,
+  scrollable: true,
+  left: 'center',
+  top: 'center',
+  width: '80%',
+  height: '80%',
+  border: 'line',
+  content: content,
+  keys: true,
+  vi: true,
+  alwaysScroll: true,
+  scrollbar: {
+    ch: ' ',
+    inverse: true
+  }
+});
+
+screen.key('q', function() {
+  return screen.destroy();
+});
+
+box.focus();
+
+screen.render();


### PR DESCRIPTION
from [original](https://github.com/chjj/blessed/pull/306)

Test case:
Added a test for a widget with huge content. On my machine, scrolling with either the keyboard or mouse is very slow and every scroll tick takes 5-10 seconds to process.

Fix:
It looks like lines[0] never contains an attr property (correct me if I'm wrong). lines.attr can however, so it seemed the intent was to call lines.attr[0] instead of lines[0].attr.

This check looks like it is related to the widget style attributes, allowing the _parseAttr to be skipped if this.style hasn't changed.

An assumption being made here is that lines.attr will be undefined if the content or width of the widget has changed, thus not allowing a skip to happen.

Another assumption that could be made is that lines.attr will always be at least length 1 if it's been cached (!== undefined). I wasn't sure if that's always the case, but I couldn't find a situation where it wasn't the case. If this assumption can be made, then the check can be simplified to

```
if (lines.attr && lines.attr[0] === attr)
```