### PR TITLE
Typo fix on install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ The blessed API itself has gone on to inspire [termui][termui] for Go.
 ## Install
 
 ``` bash
-$ npm install blessed
+$ npm install neo-blessed
 ```
 
 ## Example


### PR DESCRIPTION
Changed the install prompt to use the forked package's name instead of the default `blessed`