### PR TITLE
fix: don't swallow uncaughtException

### DIFF
--- a/lib/widgets/screen.js
+++ b/lib/widgets/screen.js
@@ -209,14 +209,11 @@ Screen.bind = function(screen) {
   Screen._bound = true;
 
   process.on('uncaughtException', Screen._exceptionHandler = function(err) {
-    if (process.listeners('uncaughtException').length > 1) {
-      return;
-    }
     Screen.instances.slice().forEach(function(screen) {
       screen.destroy();
     });
     err = err || new Error('Uncaught Exception.');
-    console.error(err.stack ? err.stack + '' : err + '');
+    process.stderr.write((err.stack || err) + "\n");
     nextTick(function() {
       process.exit(1);
     });


### PR DESCRIPTION
This fixes some issues where, for the sake of process communication,
`uncaughtException` listeners are added but don't necessarily handle it.

On the event, Screen should always shutdown.