### PR TITLE
fix(colors): restore 256 color support, drop redundant effectful ccolors decl

### DIFF
--- a/lib/colors.js
+++ b/lib/colors.js
@@ -283,23 +283,6 @@ exports.colors = (function() {
   return cols;
 })();
 
-// Map higher colors to the first 8 colors.
-// This allows translation of high colors to low colors on 8-color terminals.
-exports.ccolors = (function() {
-  var _cols = exports.vcolors.slice(), cols = exports.colors.slice(), out;
-
-  exports.vcolors = exports.vcolors.slice(0, 8);
-  exports.colors = exports.colors.slice(0, 8);
-
-  out = cols.map(exports.match);
-
-  exports.colors = cols;
-  exports.vcolors = _cols;
-  exports.ccolors = out;
-
-  return out;
-})();
-
 var colorNames = exports.colorNames = {
   // special
   default: -1,


### PR DESCRIPTION
# problem

- ccolors is declared twice. once is highly effectful and breaks 256 color support. fixes #49

# before

should have reds and oranges, but uses terminal default values:

![image](https://user-images.githubusercontent.com/1003261/85323473-ea6a4980-b47c-11ea-8ced-668fad9e5953.png)

# after

respects 256 color codes:

![image](https://user-images.githubusercontent.com/1003261/85323453-e2aaa500-b47c-11ea-9a22-82c16ed2b34c.png)
