### PR TITLE
major strict inequality snafu

### DIFF
--- a/lib/colors.js
+++ b/lib/colors.js
@@ -22,7 +22,7 @@ exports.match = function(r1, g1, b1) {
 
   var hash = (r1 << 16) | (g1 << 8) | b1;
 
-  if (exports._cache[hash] !== null) {
+  if (exports._cache[hash] != null) {
     return exports._cache[hash];
   }
 
@@ -101,7 +101,7 @@ exports.mixColors = function(c1, c2, alpha) {
   // if (c2 === 0x1ff) return c1;
   if (c1 === 0x1ff) c1 = 0;
   if (c2 === 0x1ff) c2 = 0;
-  if (alpha === null) alpha = 0.5;
+  if (alpha == null) alpha = 0.5;
 
   c1 = exports.vcolors[c1];
   var r1 = c1[0];
@@ -124,13 +124,13 @@ exports.blend = function blend(attr, attr2, alpha) {
   var name, i, c, nc;
 
   var bg = attr & 0x1ff;
-  if (attr2 !== null) {
+  if (attr2 != null) {
     var bg2 = attr2 & 0x1ff;
     if (bg === 0x1ff) bg = 0;
     if (bg2 === 0x1ff) bg2 = 0;
     bg = exports.mixColors(bg, bg2, alpha);
   } else {
-    if (blend._cache[bg] !== null) {
+    if (blend._cache[bg] != null) {
       bg = blend._cache[bg];
     // } else if (bg < 8) {
     //   bg += 8;
@@ -158,7 +158,7 @@ exports.blend = function blend(attr, attr2, alpha) {
   attr |= bg;
 
   var fg = (attr >> 9) & 0x1ff;
-  if (attr2 !== null) {
+  if (attr2 != null) {
     var fg2 = (attr2 >> 9) & 0x1ff;
     // 0, 7, 188, 231, 251
     if (fg === 0x1ff) {
@@ -170,7 +170,7 @@ exports.blend = function blend(attr, attr2, alpha) {
       fg = exports.mixColors(fg, fg2, alpha);
     }
   } else {
-    if (blend._cache[fg] !== null) {
+    if (blend._cache[fg] != null) {
       fg = blend._cache[fg];
     // } else if (fg < 8) {
     //   fg += 8;
@@ -346,7 +346,7 @@ exports.convert = function(color) {
   if (typeof color === 'number') {
   } else if (typeof color === 'string') {
     color = color.replace(/[\- ]/g, '');
-    if (colorNames[color] !== null) {
+    if (colorNames[color] != null) {
       color = colorNames[color];
     } else {
       color = exports.match(color);

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -117,7 +117,7 @@ helpers.generateTags = function(style, text) {
     }
   });
 
-  if (text !== null) {
+  if (text != null) {
     return open + text + close;
   }
 

--- a/lib/program.js
+++ b/lib/program.js
@@ -3333,12 +3333,12 @@ Program.prototype.disableMouse = function() {
 
 // Set Mouse
 Program.prototype.setMouse = function(opt, enable) {
-  if (opt.normalMouse !== null) {
+  if (opt.normalMouse != null) {
     opt.vt200Mouse = opt.normalMouse;
     opt.allMotion = opt.normalMouse;
   }
 
-  if (opt.hiliteTracking !== null) {
+  if (opt.hiliteTracking != null) {
     opt.vt200Hilite = opt.hiliteTracking;
   }
 
@@ -3361,7 +3361,7 @@ Program.prototype.setMouse = function(opt, enable) {
   //     tion Mouse Tracking.
   //     Ps = 9  -> Don't send Mouse X & Y on button press.
   // x10 mouse
-  if (opt.x10Mouse !== null) {
+  if (opt.x10Mouse != null) {
     if (opt.x10Mouse) this.setMode('?9');
     else this.resetMode('?9');
   }
@@ -3371,14 +3371,14 @@ Program.prototype.setMouse = function(opt, enable) {
   //     Ps = 1 0 0 0  -> Don't send Mouse X & Y on button press and
   //     release.  See the section Mouse Tracking.
   // vt200 mouse
-  if (opt.vt200Mouse !== null) {
+  if (opt.vt200Mouse != null) {
     if (opt.vt200Mouse) this.setMode('?1000');
     else this.resetMode('?1000');
   }
 
   //     Ps = 1 0 0 1  -> Use Hilite Mouse Tracking.
   //     Ps = 1 0 0 1  -> Don't use Hilite Mouse Tracking.
-  if (opt.vt200Hilite !== null) {
+  if (opt.vt200Hilite != null) {
     if (opt.vt200Hilite) this.setMode('?1001');
     else this.resetMode('?1001');
   }
@@ -3386,7 +3386,7 @@ Program.prototype.setMouse = function(opt, enable) {
   //     Ps = 1 0 0 2  -> Use Cell Motion Mouse Tracking.
   //     Ps = 1 0 0 2  -> Don't use Cell Motion Mouse Tracking.
   // button event mouse
-  if (opt.cellMotion !== null) {
+  if (opt.cellMotion != null) {
     if (opt.cellMotion) this.setMode('?1002');
     else this.resetMode('?1002');
   }
@@ -3394,7 +3394,7 @@ Program.prototype.setMouse = function(opt, enable) {
   //     Ps = 1 0 0 3  -> Use All Motion Mouse Tracking.
   //     Ps = 1 0 0 3  -> Don't use All Motion Mouse Tracking.
   // any event mouse
-  if (opt.allMotion !== null) {
+  if (opt.allMotion != null) {
     // NOTE: Latest versions of tmux seem to only support cellMotion (not
     // allMotion). We pass all motion through to the terminal.
     if (this.tmux && this.tmuxVersion >= 2) {
@@ -3408,51 +3408,51 @@ Program.prototype.setMouse = function(opt, enable) {
 
   //     Ps = 1 0 0 4  -> Send FocusIn/FocusOut events.
   //     Ps = 1 0 0 4  -> Don't send FocusIn/FocusOut events.
-  if (opt.sendFocus !== null) {
+  if (opt.sendFocus != null) {
     if (opt.sendFocus) this.setMode('?1004');
     else this.resetMode('?1004');
   }
 
   //     Ps = 1 0 0 5  -> Enable Extended Mouse Mode.
   //     Ps = 1 0 0 5  -> Disable Extended Mouse Mode.
-  if (opt.utfMouse !== null) {
+  if (opt.utfMouse != null) {
     if (opt.utfMouse) this.setMode('?1005');
     else this.resetMode('?1005');
   }
 
   // sgr mouse
-  if (opt.sgrMouse !== null) {
+  if (opt.sgrMouse != null) {
     if (opt.sgrMouse) this.setMode('?1006');
     else this.resetMode('?1006');
   }
 
   // urxvt mouse
-  if (opt.urxvtMouse !== null) {
+  if (opt.urxvtMouse != null) {
     if (opt.urxvtMouse) this.setMode('?1015');
     else this.resetMode('?1015');
   }
 
   // dec mouse
-  if (opt.decMouse !== null) {
+  if (opt.decMouse != null) {
     if (opt.decMouse) this._write('\x1b[1;2\'z\x1b[1;3\'{');
     else this._write('\x1b[\'z');
   }
 
   // pterm mouse
-  if (opt.ptermMouse !== null) {
+  if (opt.ptermMouse != null) {
     if (opt.ptermMouse) this._write('\x1b[>1h\x1b[>6h\x1b[>7h\x1b[>1h\x1b[>9l');
     else this._write('\x1b[>1l\x1b[>6l\x1b[>7l\x1b[>1l\x1b[>9h');
   }
 
   // jsbterm mouse
-  if (opt.jsbtermMouse !== null) {
+  if (opt.jsbtermMouse != null) {
     // + = advanced mode
     if (opt.jsbtermMouse) this._write('\x1b[0~ZwLMRK+1Q\x1b\\');
     else this._write('\x1b[0~ZwQ\x1b\\');
   }
 
   // gpm mouse
-  if (opt.gpmMouse !== null) {
+  if (opt.gpmMouse != null) {
     if (opt.gpmMouse) this.enableGpm();
     else this.disableGpm();
   }


### PR DESCRIPTION
Original blessed uses normal inequality liberally throughout the code, like to check if function arguments are undefined.

Neo blessed changes a number of these to strict inequality. Particularly in color.js, these changes alter the behavior of blessed in really weird ways.

This is a serious error since it doesn't just break coloring and other stuff. It messes with the behavior in select situations in very subtle ways. For the sake of other developers working on this it should be fixed ASAP.